### PR TITLE
Domain name change

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -5,7 +5,7 @@ import { FlagStatus } from "./index";
 global.fetch = jest.fn() as jest.Mock<Promise<Response>>;
 
 describe("createRocketflagClient", () => {
-  const apiUrl = "https://rocketflag.web.app";
+  const apiUrl = "https://api.rocketflag.app";
   const flagId = "test-flag";
   const userContext = { userId: "user123" };
 

--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@ interface UserContext {
   [key: string]: string | number | boolean;
 }
 
-const createRocketflagClient = (version = "v1", apiUrl = "https://rocketflag.web.app") => {
+const createRocketflagClient = (version = "v1", apiUrl = "https://api.rocketflag.app") => {
   const cache: { [key: string]: FlagStatus } = {};
 
   const getFlag = async (flagId: string, userContext: UserContext = {}): Promise<FlagStatus> => {


### PR DESCRIPTION
use api.rocketflag.app instead of previous rocketflag.web.app

Both work so this isn't a breaking change, but the new one is more performant.