### PR TITLE
feat: add opt-in response caching with configurable TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-05-21
+
+### Added
+- Opt-in in-memory response caching for `getFlag`. Pass `{ ttlSeconds }` as the third argument to `createRocketflagClient` to set a default TTL, or as the third argument to `getFlag` to override (or disable with `0`) per call.
+- Cache keys include the flag ID and the full user context, so different cohorts/environments cache independently.
+- Cached entries are deep-cloned on read and write so callers cannot mutate cached state.
+- README section documenting the caching API and its memory characteristics (no size cap; entries only expire on re-request).
+- Tests covering cache hits, expiry, per-call overrides, context-keyed isolation, and mutation safety.
+
 ## [1.1.0] - 2025-09-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,14 +48,13 @@ const flag = await rocketflag.getFlag("IFldMzqP5jtv9wAL", {
 ### Caching responses
 
 To avoid hitting the API on every check, you can enable an in-memory cache by
-passing a default TTL when creating the client. Provide **either**
-`ttlSeconds` or `ttlMinutes` — providing both throws. Cached entries are keyed
-by flag ID **and** the user context, so different cohorts or environments
-still resolve independently.
+passing a default `ttlSeconds` when creating the client. Cached entries are
+keyed by flag ID **and** the user context, so different cohorts or
+environments still resolve independently.
 
 ```js
 // Cache flag responses for 5 minutes.
-const rocketflag = createRocketflagClient(undefined, undefined, { ttlMinutes: 5 });
+const rocketflag = createRocketflagClient(undefined, undefined, { ttlSeconds: 300 });
 
 // First call hits the API; subsequent calls within 5 minutes are served from cache.
 const flag = await rocketflag.getFlag("IFldMzqP5jtv9wAL", { cohort: "beta" });
@@ -73,7 +72,10 @@ const flag = await rocketflag.getFlag("IFldMzqP5jtv9wAL", {}, { ttlSeconds: 10 }
 ```
 
 Caching is opt-in — without a client default or per-call TTL, every call goes
-to the API.
+to the API. The cache has no size cap and entries are only evicted when their
+key is re-requested after expiry; if you call with high-cardinality user
+contexts (e.g. per-user IDs), construct a new client periodically to release
+memory.
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,35 @@ const flag = await rocketflag.getFlag("IFldMzqP5jtv9wAL", {
 });
 ```
 
+### Caching responses
+
+To avoid hitting the API on every check, you can enable an in-memory cache by
+passing a default TTL (in milliseconds) when creating the client. Cached
+entries are keyed by flag ID **and** the user context, so different cohorts or
+environments still resolve independently.
+
+```js
+// Cache flag responses for 5 minutes.
+const rocketflag = createRocketflagClient(undefined, undefined, 5 * 60 * 1000);
+
+// First call hits the API; subsequent calls within 5 minutes are served from cache.
+const flag = await rocketflag.getFlag("IFldMzqP5jtv9wAL", { cohort: "beta" });
+```
+
+You can override the TTL for a single call, or disable caching for that call by
+passing `0`:
+
+```js
+// Force a fresh fetch, bypassing the cache.
+const flag = await rocketflag.getFlag("IFldMzqP5jtv9wAL", {}, { ttlMs: 0 });
+
+// Use a shorter TTL just for this call.
+const flag = await rocketflag.getFlag("IFldMzqP5jtv9wAL", {}, { ttlMs: 10_000 });
+```
+
+Caching is opt-in — without a default TTL or per-call `ttlMs`, every call goes
+to the API.
+
 ## Error Handling
 
 The SDK can throw the following errors:

--- a/README.md
+++ b/README.md
@@ -48,13 +48,14 @@ const flag = await rocketflag.getFlag("IFldMzqP5jtv9wAL", {
 ### Caching responses
 
 To avoid hitting the API on every check, you can enable an in-memory cache by
-passing a default TTL (in milliseconds) when creating the client. Cached
-entries are keyed by flag ID **and** the user context, so different cohorts or
-environments still resolve independently.
+passing a default TTL when creating the client. Provide **either**
+`ttlSeconds` or `ttlMinutes` — providing both throws. Cached entries are keyed
+by flag ID **and** the user context, so different cohorts or environments
+still resolve independently.
 
 ```js
 // Cache flag responses for 5 minutes.
-const rocketflag = createRocketflagClient(undefined, undefined, 5 * 60 * 1000);
+const rocketflag = createRocketflagClient(undefined, undefined, { ttlMinutes: 5 });
 
 // First call hits the API; subsequent calls within 5 minutes are served from cache.
 const flag = await rocketflag.getFlag("IFldMzqP5jtv9wAL", { cohort: "beta" });
@@ -65,13 +66,13 @@ passing `0`:
 
 ```js
 // Force a fresh fetch, bypassing the cache.
-const flag = await rocketflag.getFlag("IFldMzqP5jtv9wAL", {}, { ttlMs: 0 });
+const flag = await rocketflag.getFlag("IFldMzqP5jtv9wAL", {}, { ttlSeconds: 0 });
 
 // Use a shorter TTL just for this call.
-const flag = await rocketflag.getFlag("IFldMzqP5jtv9wAL", {}, { ttlMs: 10_000 });
+const flag = await rocketflag.getFlag("IFldMzqP5jtv9wAL", {}, { ttlSeconds: 10 });
 ```
 
-Caching is opt-in — without a default TTL or per-call `ttlMs`, every call goes
+Caching is opt-in — without a client default or per-call TTL, every call goes
 to the API.
 
 ## Error Handling

--- a/index.test.ts
+++ b/index.test.ts
@@ -228,20 +228,28 @@ describe("createRocketflagClient", () => {
         expect(fetch).toHaveBeenCalledTimes(2);
       });
 
-      it("returns a cached value within the default TTL", async () => {
+      it("returns a cached value within the default TTL (ttlMinutes)", async () => {
         (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockFlag) });
-        const client = createRocketflagClient(undefined, undefined, 60_000);
+        const client = createRocketflagClient(undefined, undefined, { ttlMinutes: 1 });
         const first = await client.getFlag(flagId, { cohort: "beta" });
         const second = await client.getFlag(flagId, { cohort: "beta" });
         expect(fetch).toHaveBeenCalledTimes(1);
         expect(second).toEqual(first);
       });
 
+      it("returns a cached value within the default TTL (ttlSeconds)", async () => {
+        (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockFlag) });
+        const client = createRocketflagClient(undefined, undefined, { ttlSeconds: 30 });
+        await client.getFlag(flagId);
+        await client.getFlag(flagId);
+        expect(fetch).toHaveBeenCalledTimes(1);
+      });
+
       it("refetches after the TTL elapses", async () => {
         (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockFlag) });
         jest.useFakeTimers();
         try {
-          const client = createRocketflagClient(undefined, undefined, 1_000);
+          const client = createRocketflagClient(undefined, undefined, { ttlSeconds: 1 });
           await client.getFlag(flagId);
           jest.setSystemTime(Date.now() + 1_500);
           (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockFlag) });
@@ -254,7 +262,7 @@ describe("createRocketflagClient", () => {
 
       it("keys cache entries by user context", async () => {
         (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockFlag) });
-        const client = createRocketflagClient(undefined, undefined, 60_000);
+        const client = createRocketflagClient(undefined, undefined, { ttlMinutes: 1 });
         await client.getFlag(flagId, { cohort: "alpha" });
         await client.getFlag(flagId, { cohort: "beta" });
         expect(fetch).toHaveBeenCalledTimes(2);
@@ -262,18 +270,31 @@ describe("createRocketflagClient", () => {
 
       it("allows per-call TTL override to disable caching", async () => {
         (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockFlag) });
-        const client = createRocketflagClient(undefined, undefined, 60_000);
-        await client.getFlag(flagId, {}, { ttlMs: 0 });
-        await client.getFlag(flagId, {}, { ttlMs: 0 });
+        const client = createRocketflagClient(undefined, undefined, { ttlMinutes: 1 });
+        await client.getFlag(flagId, {}, { ttlSeconds: 0 });
+        await client.getFlag(flagId, {}, { ttlSeconds: 0 });
         expect(fetch).toHaveBeenCalledTimes(2);
       });
 
       it("allows per-call TTL to enable caching without a client default", async () => {
         (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockFlag) });
         const client = createRocketflagClient();
-        await client.getFlag(flagId, {}, { ttlMs: 60_000 });
-        await client.getFlag(flagId, {}, { ttlMs: 60_000 });
+        await client.getFlag(flagId, {}, { ttlMinutes: 1 });
+        await client.getFlag(flagId, {}, { ttlMinutes: 1 });
         expect(fetch).toHaveBeenCalledTimes(1);
+      });
+
+      it("throws if both ttlSeconds and ttlMinutes are set on client", () => {
+        expect(() =>
+          createRocketflagClient(undefined, undefined, { ttlSeconds: 30, ttlMinutes: 1 }),
+        ).toThrow("client cache options cannot specify both ttlSeconds and ttlMinutes");
+      });
+
+      it("throws if both ttlSeconds and ttlMinutes are set per call", async () => {
+        const client = createRocketflagClient();
+        await expect(client.getFlag(flagId, {}, { ttlSeconds: 30, ttlMinutes: 1 })).rejects.toThrow(
+          "call cache options cannot specify both ttlSeconds and ttlMinutes",
+        );
       });
     });
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -217,6 +217,66 @@ describe("createRocketflagClient", () => {
       await expect(client.getFlag(flagId, userContext)).rejects.toThrow("Invalid response format: response is not an object");
     });
 
+    describe("caching", () => {
+      const mockFlag: FlagStatus = { name: "Test Flag", enabled: true, id: flagId };
+
+      it("does not cache when no TTL is configured", async () => {
+        (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockFlag) });
+        const client = createRocketflagClient();
+        await client.getFlag(flagId);
+        await client.getFlag(flagId);
+        expect(fetch).toHaveBeenCalledTimes(2);
+      });
+
+      it("returns a cached value within the default TTL", async () => {
+        (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockFlag) });
+        const client = createRocketflagClient(undefined, undefined, 60_000);
+        const first = await client.getFlag(flagId, { cohort: "beta" });
+        const second = await client.getFlag(flagId, { cohort: "beta" });
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(second).toEqual(first);
+      });
+
+      it("refetches after the TTL elapses", async () => {
+        (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockFlag) });
+        jest.useFakeTimers();
+        try {
+          const client = createRocketflagClient(undefined, undefined, 1_000);
+          await client.getFlag(flagId);
+          jest.setSystemTime(Date.now() + 1_500);
+          (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockFlag) });
+          await client.getFlag(flagId);
+          expect(fetch).toHaveBeenCalledTimes(2);
+        } finally {
+          jest.useRealTimers();
+        }
+      });
+
+      it("keys cache entries by user context", async () => {
+        (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockFlag) });
+        const client = createRocketflagClient(undefined, undefined, 60_000);
+        await client.getFlag(flagId, { cohort: "alpha" });
+        await client.getFlag(flagId, { cohort: "beta" });
+        expect(fetch).toHaveBeenCalledTimes(2);
+      });
+
+      it("allows per-call TTL override to disable caching", async () => {
+        (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockFlag) });
+        const client = createRocketflagClient(undefined, undefined, 60_000);
+        await client.getFlag(flagId, {}, { ttlMs: 0 });
+        await client.getFlag(flagId, {}, { ttlMs: 0 });
+        expect(fetch).toHaveBeenCalledTimes(2);
+      });
+
+      it("allows per-call TTL to enable caching without a client default", async () => {
+        (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockFlag) });
+        const client = createRocketflagClient();
+        await client.getFlag(flagId, {}, { ttlMs: 60_000 });
+        await client.getFlag(flagId, {}, { ttlMs: 60_000 });
+        expect(fetch).toHaveBeenCalledTimes(1);
+      });
+    });
+
     it("should throw an InvalidResponseError if validateFlag fails", async () => {
       (fetch as jest.Mock).mockResolvedValue({
         ok: true,

--- a/index.test.ts
+++ b/index.test.ts
@@ -228,21 +228,13 @@ describe("createRocketflagClient", () => {
         expect(fetch).toHaveBeenCalledTimes(2);
       });
 
-      it("returns a cached value within the default TTL (ttlMinutes)", async () => {
+      it("returns a cached value within the default TTL", async () => {
         (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockFlag) });
-        const client = createRocketflagClient(undefined, undefined, { ttlMinutes: 1 });
+        const client = createRocketflagClient(undefined, undefined, { ttlSeconds: 60 });
         const first = await client.getFlag(flagId, { cohort: "beta" });
         const second = await client.getFlag(flagId, { cohort: "beta" });
         expect(fetch).toHaveBeenCalledTimes(1);
         expect(second).toEqual(first);
-      });
-
-      it("returns a cached value within the default TTL (ttlSeconds)", async () => {
-        (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockFlag) });
-        const client = createRocketflagClient(undefined, undefined, { ttlSeconds: 30 });
-        await client.getFlag(flagId);
-        await client.getFlag(flagId);
-        expect(fetch).toHaveBeenCalledTimes(1);
       });
 
       it("refetches after the TTL elapses", async () => {
@@ -262,7 +254,7 @@ describe("createRocketflagClient", () => {
 
       it("keys cache entries by user context", async () => {
         (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockFlag) });
-        const client = createRocketflagClient(undefined, undefined, { ttlMinutes: 1 });
+        const client = createRocketflagClient(undefined, undefined, { ttlSeconds: 60 });
         await client.getFlag(flagId, { cohort: "alpha" });
         await client.getFlag(flagId, { cohort: "beta" });
         expect(fetch).toHaveBeenCalledTimes(2);
@@ -270,7 +262,7 @@ describe("createRocketflagClient", () => {
 
       it("allows per-call TTL override to disable caching", async () => {
         (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockFlag) });
-        const client = createRocketflagClient(undefined, undefined, { ttlMinutes: 1 });
+        const client = createRocketflagClient(undefined, undefined, { ttlSeconds: 60 });
         await client.getFlag(flagId, {}, { ttlSeconds: 0 });
         await client.getFlag(flagId, {}, { ttlSeconds: 0 });
         expect(fetch).toHaveBeenCalledTimes(2);
@@ -279,22 +271,19 @@ describe("createRocketflagClient", () => {
       it("allows per-call TTL to enable caching without a client default", async () => {
         (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockFlag) });
         const client = createRocketflagClient();
-        await client.getFlag(flagId, {}, { ttlMinutes: 1 });
-        await client.getFlag(flagId, {}, { ttlMinutes: 1 });
+        await client.getFlag(flagId, {}, { ttlSeconds: 60 });
+        await client.getFlag(flagId, {}, { ttlSeconds: 60 });
         expect(fetch).toHaveBeenCalledTimes(1);
       });
 
-      it("throws if both ttlSeconds and ttlMinutes are set on client", () => {
-        expect(() =>
-          createRocketflagClient(undefined, undefined, { ttlSeconds: 30, ttlMinutes: 1 }),
-        ).toThrow("client cache options cannot specify both ttlSeconds and ttlMinutes");
-      });
-
-      it("throws if both ttlSeconds and ttlMinutes are set per call", async () => {
-        const client = createRocketflagClient();
-        await expect(client.getFlag(flagId, {}, { ttlSeconds: 30, ttlMinutes: 1 })).rejects.toThrow(
-          "call cache options cannot specify both ttlSeconds and ttlMinutes",
-        );
+      it("isolates cached values from caller mutation", async () => {
+        (fetch as jest.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve({ ...mockFlag }) });
+        const client = createRocketflagClient(undefined, undefined, { ttlSeconds: 60 });
+        const first = await client.getFlag(flagId);
+        first.name = "mutated";
+        const second = await client.getFlag(flagId);
+        expect(second.name).toBe(mockFlag.name);
+        expect(fetch).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/index.ts
+++ b/index.ts
@@ -17,8 +17,14 @@ export interface UserContext {
   env?: string;
 }
 
+export interface CacheOptions {
+  ttlSeconds?: number;
+  ttlMinutes?: number;
+}
+
 export interface CallOptions {
-  ttlMs?: number;
+  ttlSeconds?: number;
+  ttlMinutes?: number;
 }
 
 export interface RocketFlagClient {
@@ -27,11 +33,21 @@ export interface RocketFlagClient {
 
 type CacheEntry = { flag: FlagStatus; expiresAt: number };
 
+const resolveTtlMs = (opts: CacheOptions | CallOptions, label: string): number | undefined => {
+  if (opts.ttlSeconds !== undefined && opts.ttlMinutes !== undefined) {
+    throw new Error(`${label} cache options cannot specify both ttlSeconds and ttlMinutes`);
+  }
+  if (opts.ttlSeconds !== undefined) return opts.ttlSeconds * 1_000;
+  if (opts.ttlMinutes !== undefined) return opts.ttlMinutes * 60_000;
+  return undefined;
+};
+
 const createRocketflagClient = (
   version = DEFAULT_VERSION,
   apiUrl = DEFAULT_API_URL,
-  defaultCacheTtlMs = 0,
+  cacheOptions: CacheOptions = {},
 ): RocketFlagClient => {
+  const defaultTtlMs = resolveTtlMs(cacheOptions, "client") ?? 0;
   const cache: Map<string, CacheEntry> = new Map();
 
   const getFlag = async (flagId: string, userContext: UserContext = {}, options: CallOptions = {}): Promise<FlagStatus> => {
@@ -61,7 +77,8 @@ const createRocketflagClient = (
     });
     url.searchParams.sort();
 
-    const effectiveTtl = options.ttlMs ?? defaultCacheTtlMs;
+    const callTtlMs = resolveTtlMs(options, "call");
+    const effectiveTtl = callTtlMs ?? defaultTtlMs;
     const cacheKey = `${flagId}?${url.searchParams.toString()}`;
     if (effectiveTtl > 0) {
       const entry = cache.get(cacheKey);

--- a/index.ts
+++ b/index.ts
@@ -19,13 +19,9 @@ export interface UserContext {
 
 export interface CacheOptions {
   ttlSeconds?: number;
-  ttlMinutes?: number;
 }
 
-export interface CallOptions {
-  ttlSeconds?: number;
-  ttlMinutes?: number;
-}
+export type CallOptions = CacheOptions;
 
 export interface RocketFlagClient {
   getFlag: (flagId: string, context?: UserContext, options?: CallOptions) => Promise<FlagStatus>;
@@ -33,21 +29,12 @@ export interface RocketFlagClient {
 
 type CacheEntry = { flag: FlagStatus; expiresAt: number };
 
-const resolveTtlMs = (opts: CacheOptions | CallOptions, label: string): number | undefined => {
-  if (opts.ttlSeconds !== undefined && opts.ttlMinutes !== undefined) {
-    throw new Error(`${label} cache options cannot specify both ttlSeconds and ttlMinutes`);
-  }
-  if (opts.ttlSeconds !== undefined) return opts.ttlSeconds * 1_000;
-  if (opts.ttlMinutes !== undefined) return opts.ttlMinutes * 60_000;
-  return undefined;
-};
-
 const createRocketflagClient = (
   version = DEFAULT_VERSION,
   apiUrl = DEFAULT_API_URL,
   cacheOptions: CacheOptions = {},
 ): RocketFlagClient => {
-  const defaultTtlMs = resolveTtlMs(cacheOptions, "client") ?? 0;
+  const defaultTtlMs = cacheOptions.ttlSeconds !== undefined ? cacheOptions.ttlSeconds * 1_000 : 0;
   const cache: Map<string, CacheEntry> = new Map();
 
   const getFlag = async (flagId: string, userContext: UserContext = {}, options: CallOptions = {}): Promise<FlagStatus> => {
@@ -75,16 +62,17 @@ const createRocketflagClient = (
     Object.entries(userContext).forEach(([key, value]) => {
       url.searchParams.append(key, value.toString());
     });
-    url.searchParams.sort();
 
-    const callTtlMs = resolveTtlMs(options, "call");
-    const effectiveTtl = callTtlMs ?? defaultTtlMs;
-    const cacheKey = `${flagId}?${url.searchParams.toString()}`;
+    const effectiveTtl = options.ttlSeconds !== undefined ? options.ttlSeconds * 1_000 : defaultTtlMs;
+    let cacheKey = "";
     if (effectiveTtl > 0) {
+      const sortedParams = new URLSearchParams(url.searchParams);
+      sortedParams.sort();
+      cacheKey = `${flagId}?${sortedParams.toString()}`;
       const entry = cache.get(cacheKey);
       if (entry) {
         if (entry.expiresAt > Date.now()) {
-          return entry.flag;
+          return structuredClone(entry.flag);
         }
         cache.delete(cacheKey);
       }
@@ -110,7 +98,7 @@ const createRocketflagClient = (
     if (!validateFlag(response)) throw new InvalidResponseError("Invalid response from server");
 
     if (effectiveTtl > 0) {
-      cache.set(cacheKey, { flag: response, expiresAt: Date.now() + effectiveTtl });
+      cache.set(cacheKey, { flag: structuredClone(response), expiresAt: Date.now() + effectiveTtl });
     }
 
     return response;

--- a/index.ts
+++ b/index.ts
@@ -17,12 +17,24 @@ export interface UserContext {
   env?: string;
 }
 
-export interface RocketFlagClient {
-  getFlag: (flagId: string, context?: UserContext) => Promise<FlagStatus>;
+export interface CallOptions {
+  ttlMs?: number;
 }
 
-const createRocketflagClient = (version = DEFAULT_VERSION, apiUrl = DEFAULT_API_URL): RocketFlagClient => {
-  const getFlag = async (flagId: string, userContext: UserContext = {}): Promise<FlagStatus> => {
+export interface RocketFlagClient {
+  getFlag: (flagId: string, context?: UserContext, options?: CallOptions) => Promise<FlagStatus>;
+}
+
+type CacheEntry = { flag: FlagStatus; expiresAt: number };
+
+const createRocketflagClient = (
+  version = DEFAULT_VERSION,
+  apiUrl = DEFAULT_API_URL,
+  defaultCacheTtlMs = 0,
+): RocketFlagClient => {
+  const cache: Map<string, CacheEntry> = new Map();
+
+  const getFlag = async (flagId: string, userContext: UserContext = {}, options: CallOptions = {}): Promise<FlagStatus> => {
     if (!flagId) {
       throw new Error("flagId is required");
     }
@@ -47,6 +59,19 @@ const createRocketflagClient = (version = DEFAULT_VERSION, apiUrl = DEFAULT_API_
     Object.entries(userContext).forEach(([key, value]) => {
       url.searchParams.append(key, value.toString());
     });
+    url.searchParams.sort();
+
+    const effectiveTtl = options.ttlMs ?? defaultCacheTtlMs;
+    const cacheKey = `${flagId}?${url.searchParams.toString()}`;
+    if (effectiveTtl > 0) {
+      const entry = cache.get(cacheKey);
+      if (entry) {
+        if (entry.expiresAt > Date.now()) {
+          return entry.flag;
+        }
+        cache.delete(cacheKey);
+      }
+    }
 
     let raw: Response;
     try {
@@ -66,6 +91,10 @@ const createRocketflagClient = (version = DEFAULT_VERSION, apiUrl = DEFAULT_API_
 
     if (!response || typeof response !== "object") throw new InvalidResponseError("Invalid response format: response is not an object");
     if (!validateFlag(response)) throw new InvalidResponseError("Invalid response from server");
+
+    if (effectiveTtl > 0) {
+      cache.set(cacheKey, { flag: response, expiresAt: Date.now() + effectiveTtl });
+    }
 
     return response;
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketflag/node-sdk",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "author": "RocketFlag Developers (https://rocketflag.app)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Adds an optional defaultCacheTtlMs parameter to createRocketflagClient and a per-call { ttlMs } override on getFlag. Cache keys include the user context so different cohorts/envs resolve independently. Caching is opt-in and backwards-compatible.