### PR TITLE
Ship dual ESM and CommonJS builds to fix bundler interop issues

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -46,6 +46,6 @@ jobs:
         run: |
           cp -r *.md ./dist/ && \
           cp package.json ./dist/package.json && \
-          cd ./dist && rm *.test.*
+          rm -f ./dist/cjs/*.test.* ./dist/esm/*.test.*
       - name: Publish
         run: npm publish ./dist --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-06-15
+
+### Added
+- The package now ships both an ES module build (`./esm`) and a CommonJS build (`./cjs`), wired through the `exports` map with `import`/`require` conditions. ESM consumers (Vite, Angular, and other bundlers) now load real ESM where `import createRocketflagClient from "@rocketflag/node-sdk"` resolves directly to the client factory function.
+
+### Fixed
+- Default import resolving to a module namespace object (`{ default: fn }`) instead of the client factory under bundlers that don't honour the CommonJS `__esModule`/`exports.default` interop convention (e.g. Vite 8 / Rolldown), which caused `createRocketflagClient is not a function`. Shipping a true ESM build removes the interop ambiguity.
+
+### Notes
+- Fully backwards compatible. CommonJS `require("@rocketflag/node-sdk").default` (including on Node 18) and the `@rocketflag/node-sdk/errors` subpath continue to work unchanged.
+
 ## [1.2.0] - 2026-05-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ effectively.
 npm install @rocketflag/node-sdk
 ```
 
+The SDK ships both ES module and CommonJS builds, so it works with modern
+bundlers (Vite, Angular, webpack, …) and Node — via either `import` or
+`require` — on Node 18 and above.
+
+```js
+// ESM / bundlers
+import createRocketflagClient from "@rocketflag/node-sdk";
+
+// CommonJS
+const { default: createRocketflagClient } = require("@rocketflag/node-sdk");
+```
+
 ## Basic Usage
 
 ### Setup

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
-import { APIError, InvalidResponseError, NetworkError } from "./errors";
-import { validateFlag } from "./validateFlag";
+import { APIError, InvalidResponseError, NetworkError } from "./errors.js";
+import { validateFlag } from "./validateFlag.js";
 
 const GET_METHOD = "GET";
 const DEFAULT_API_URL = "https://api.rocketflag.app";

--- a/jest.config.js
+++ b/jest.config.js
@@ -89,7 +89,12 @@ const config = {
   // ],
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-  // moduleNameMapper: {},
+  // Source files use explicit ".js" extensions on relative imports (required for
+  // the ESM build to resolve at runtime). Strip them so ts-jest resolves the
+  // ".ts" sources during testing.
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   // modulePathIgnorePatterns: [],
@@ -160,9 +165,10 @@ const config = {
   // ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  // testPathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  // Ignore the compiled output: the CI test job runs against a populated ./dist,
+  // and its ESM build can't be executed by Jest's CommonJS runner. Tests run
+  // from the TypeScript sources only.
+  testPathIgnorePatterns: ["/node_modules/", "/dist/"],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],

--- a/package.json
+++ b/package.json
@@ -1,11 +1,42 @@
 {
   "name": "@rocketflag/node-sdk",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "RocketFlag Developers (https://rocketflag.app)",
-  "main": "index.js",
+  "main": "./cjs/index.js",
+  "module": "./esm/index.js",
+  "types": "./cjs/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./esm/index.d.ts",
+        "default": "./esm/index.js"
+      },
+      "require": {
+        "types": "./cjs/index.d.ts",
+        "default": "./cjs/index.js"
+      }
+    },
+    "./errors": {
+      "import": {
+        "types": "./esm/errors.d.ts",
+        "default": "./esm/errors.js"
+      },
+      "require": {
+        "types": "./cjs/errors.d.ts",
+        "default": "./cjs/errors.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "test": "jest",
-    "build": "tsc -p ./tsconfig.json",
+    "build": "npm run build:cjs && npm run build:esm && node ./scripts/postbuild.mjs",
+    "build:cjs": "tsc -p ./tsconfig.json",
+    "build:esm": "tsc -p ./tsconfig.esm.json",
     "lint": "eslint . --ext .ts"
   },
   "keywords": [

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -1,0 +1,20 @@
+// Writes the module-type marker into each build output directory so that Node
+// interprets the files correctly regardless of the published package's top-level
+// "type": dist/cjs/* are CommonJS, dist/esm/* are ES modules. Without the esm
+// marker, Node would parse the ESM output as CommonJS and throw on `import`.
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const markers = [
+  ["dist/cjs/package.json", { type: "commonjs" }],
+  ["dist/esm/package.json", { type: "module" }],
+];
+
+for (const [relPath, contents] of markers) {
+  const target = resolve(root, relPath);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, JSON.stringify(contents, null, 2) + "\n");
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist/esm"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,10 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "CommonJS",
+    "moduleResolution": "Node",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "./dist",
+    "outDir": "./dist/cjs",
     "declaration": true,
 
     /* Type Checking */

--- a/validateFlag.ts
+++ b/validateFlag.ts
@@ -1,4 +1,4 @@
-import { FlagStatus } from "./index";
+import type { FlagStatus } from "./index.js";
 
 export const validateFlag = (flag: object): flag is FlagStatus => {
   return (


### PR DESCRIPTION
Adds separate `dist/esm/` (ES modules) and `dist/cjs/` (CommonJS) builds with conditional exports. Fixes `createRocketflagClient is not a function` errors in Vite/Rolldown and other bundlers that don't handle CommonJS default export interop. Source files now use explicit `.js` extensions on imports for ESM compatibility. Fully backwards compatible with existing CommonJS consumers.